### PR TITLE
Add explicit OAuth scopes to appsscript.json

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -2,6 +2,10 @@
   "timeZone": "America/Chicago",
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
+  "oauthScopes": [
+      "https://www.googleapis.com/auth/calendar",
+      "https://www.googleapis.com/auth/script.external_request"
+  ],
   "dependencies": {
     "enabledAdvancedServices": [
       {


### PR DESCRIPTION
Without [explicitly declaring OAuth scopes](https://developers.google.com/apps-script/concepts/scopes#setting_explicit_scopes) it will use Oauth scopes defined in [BatchRequest library](https://github.com/tanaikech/BatchRequest/blob/master/appsscript.json), which also include read/write access to mail and drive.