### PR TITLE
Handle calendars shared with free/busy permission

### DIFF
--- a/SyncCalendarsIntoOne.gs
+++ b/SyncCalendarsIntoOne.gs
@@ -113,7 +113,7 @@ function createEvents(startTime, endTime) {
         method: 'POST',
         endpoint: `${ENDPOINT_BASE}/${CALENDAR_TO_MERGE_INTO}/events`,
         requestBody: {
-          summary: `${SEARCH_CHARACTER}${calendarName} ${event.summary}`,
+          summary: `${SEARCH_CHARACTER}${calendarName} ${event.summary ? event.summary : "busy"}`,
           location: event.location,
           description: event.description,
           start: event.start,


### PR DESCRIPTION
This small change handles cases where the permission for a shared calendar is limited to seeing free/busy. 

In this case, normally the events will show up visually with a summary of "busy," but in the API response, the value of `summary` is returned as `undefined`, which after using this script, is ultimately displayed as "undefined" on the combined calendar. 

This adjustment checks for to see if `event.summary` is undefined, and if so, sets the summary for the new event on the combined calendar to "busy".

<img width="500" alt="Screenshot 2022-10-07 at 1 30 27 PM" src="https://user-images.githubusercontent.com/6485697/194617548-43795165-0b51-407d-875f-f25f05c3e619.png">
