### PR TITLE
Add conference data to events

### DIFF
--- a/SyncCalendarsIntoOne.gs
+++ b/SyncCalendarsIntoOne.gs
@@ -111,13 +111,14 @@ function createEvents(startTime, endTime) {
 
       requestBody.push({
         method: 'POST',
-        endpoint: `${ENDPOINT_BASE}/${CALENDAR_TO_MERGE_INTO}/events`,
+        endpoint: `${ENDPOINT_BASE}/${CALENDAR_TO_MERGE_INTO}/events?conferenceDataVersion=1`,
         requestBody: {
           summary: `${SEARCH_CHARACTER}${calendarName} ${event.summary}`,
           location: event.location,
           description: event.description,
           start: event.start,
           end: event.end,
+          conferenceData: event.conferenceData,
         },
       });
     });


### PR DESCRIPTION
With this change, `conferenceData` would also be copied over to the new events.

<img width="376" alt="image" src="https://user-images.githubusercontent.com/52419977/205966225-f1ecce19-92e9-4a26-9a43-cf453d18f4f1.png">


For reference:
https://developers.google.com/calendar/api/v3/reference/events/insert





Property name | Value | Description
-- | -- | --
conferenceData (request body) | nested object | The conference-related information, such as details of a Google Meet conference. To persist your changes, remember to set the conferenceDataVersion request parameter to 1 for all event modification requests.
conferenceDataVersion (query param) | integer | Version number of conference data supported by the API client.  Version 0 assumes no conference data support and ignores conference  data in the event's body. Version 1 enables support for copying of  ConferenceData as well as for creating new conferences using the  createRequest field of conferenceData. The default is 0.           Acceptable values are 0 to 1, inclusive.





