### PR TITLE
Add ability to sync calendars from "My calendars"

### DIFF
--- a/SyncCalendarsIntoOne.gs
+++ b/SyncCalendarsIntoOne.gs
@@ -3,6 +3,8 @@
 // Use "" if you want none.
 const CALENDARS_TO_MERGE = {
   "[Personal]": "calendar-id@gmail.com",
+  // Example of additional calendars from "My Calendars"
+  "[Custom]": "calendar-id@group.calendar.google.com",
   "[Work]": "calendar-id@gmail.com",
 }
 
@@ -61,7 +63,10 @@ function deleteEvents(startTime, endTime) {
 
   const requestBody = events.map((e, i) => ({
     method: "DELETE",
-    endpoint: `${ENDPOINT_BASE}/${CALENDAR_TO_MERGE_INTO}/events/${e.getId().replace("@google.com", "")}`,
+    endpoint: `${ENDPOINT_BASE}/${CALENDAR_TO_MERGE_INTO}/events/${e
+      .getId()
+      .replace("@google.com", "")
+      .replace("@group.calendar.google.com", "")}`,
   }))
 
   if (requestBody && requestBody.length) {


### PR DESCRIPTION
### Change made:

Thanks again for making this. I wanted to share a change I made that just adds the ability to import calendars from "My Calendars".

### Reason:
I recently started syncing a todo-app with my calendar to create time blocks. I wanted:
- A: My calendar to show that I'm busy without showing details about my time boxing.
- B: My own personal calendar to show details for my time boxing.

I have a modification of this script [here](https://gist.github.com/rfearing/275680e77974ab09b82405a60679123a) that imports all events without details, but I didn't want to presume that others would want that as well, so I left that out of the PR.

This allows me to create a separate calendar for my todo app integration but I figured there might be other use cases someone would want to add a calendar from "My Calendars" e.g. a company or team calendar.