### PR TITLE
Don't sync declined events

### DIFF
--- a/SyncCalendarsIntoOne.gs
+++ b/SyncCalendarsIntoOne.gs
@@ -111,6 +111,11 @@ function createEvents(startTime, endTime) {
       if (event.transparency && event.transparency === "transparent") {
         return
       }
+      
+      // Don't copy declined events.
+      if (event.attendees && event.attendees.find((at) => at.self) && event.attendees.find((at) => at.self)['responseStatus'] == 'declined') {
+        return
+      }
 
       // If event.summary is undefined, empty, or null, set it to default title
       if (!event.summary || event.summary === "") {

--- a/SyncCalendarsIntoOne.gs
+++ b/SyncCalendarsIntoOne.gs
@@ -21,6 +21,9 @@ const DEFAULT_EVENT_TITLE = "Busy"
 // https://unicode-table.com/en/200B/
 const SEARCH_CHARACTER = "\u200B"
 
+// Do not sync declined events. Default: false (do sync)
+const DO_NOT_SYNC_DECLINED = false
+
 // ----------------------------------------------------------------------------
 // DO NOT TOUCH FROM HERE ON
 // ----------------------------------------------------------------------------
@@ -113,7 +116,7 @@ function createEvents(startTime, endTime) {
       }
       
       // Don't copy declined events.
-      if (event.attendees && event.attendees.find((at) => at.self) && event.attendees.find((at) => at.self)['responseStatus'] == 'declined') {
+      if (DO_NOT_SYNC_DECLINED && event.attendees && event.attendees.find((at) => at.self) && event.attendees.find((at) => at.self)['responseStatus'] == 'declined') {
         return
       }
 


### PR DESCRIPTION
This prevents syncing an event where you have declined the invitation. This is useful since declining an invitation does not automatically delete the event from your calendar.

This code could probably be improved with optional chaining, but this is the version I know works.

